### PR TITLE
Added configurable output file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,10 @@ old-results
 *.gz
 vt-hosts-db.json
 flo-old.ini
+
+# Vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Default Mode - Read Hashes from File
 
 ## Usage
 
-    usage: munin.py [-h] [-f path] [-c cache-db] [-i ini-file] [-s sample-folder]
-                    [--comment] [-p vt-comment-prefix] [--download]
-                    [-d download_path] [--nocache] [--intense] 
-                    [--nocsv] [--verifycert] [--sort] [--debug]
+    usage: munin.py [-h] [-f path] [-o output] [-c cache-db] [-i ini-file]
+                    [-s sample-folder] [--comment] [-p vt-comment-prefix]
+                    [--download] [-d download_path] [--nocache] [--nocsv]
+                    [--verifycert] [--sort] [--web] [-w port] [--cli] [--debug]
 
     Online Hash Checker
 
@@ -42,6 +42,7 @@ Default Mode - Read Hashes from File
       -h, --help            show this help message and exit
       -f path               File to process (hash line by line OR csv with hash in
                             each line - auto-detects position and comment)
+      -o output             Output file for results (CSV)
       -c cache-db           Name of the cache database file (default: vt-hash-
                             db.pkl)
       -i ini-file           Name of the ini file that holds the API keys
@@ -54,12 +55,14 @@ Default Mode - Read Hashes from File
       -d download_path      Output Path for Sample Download from Hybrid Analysis.
                             Folder must exist
       --nocache             Do not use cache database file
-      --intense             Do use PhantomJS to parse the permalink (used to
-                            extract user comments on samples)
       --nocsv               Do not write a CSV with the results
       --verifycert          Verify SSL/TLS certificates
-      --sort                Sort the input lines (useful for VT retrohunt results)
+      --sort                Sort the input lines
+      --web                 Run Munin as web service
+      -w port               Web service port
+      --cli                 Run Munin in command line interface mode
       --debug               Debug output
+
 
 ## Features
 

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -105,27 +105,35 @@ def header_function(header_raw):
     return headers
 
 
-def generateResultFilename(inputFileName):
+def generateResultFilename(inputFileName, outputFileName):
     """
-    Generate a result file name based on the input name
-    :param inputName: name of the processed file
+    Generate a result file name based on the input name or the passed argument
+    :param inputFileName: name of the processed file
+    :param outputFileName: name of the output file
     :return alreadyExists: returns True if the file already exists
     :return resultFile: name of the output file
     """
     alreadyExists = False
     # CLI
     if not inputFileName:
-        resultFile = "check-results_{0}.csv".format(datetime.now().strftime("%Y-%m-%d"))
+        if not outputFileName:
+            resultFile = "check-results_{0}.csv".format(datetime.now().strftime("%Y-%m-%d"))
+        else:
+            resultFile = outputFileName
         if os.path.exists(resultFile):
             alreadyExists = True
-        return alreadyExists, resultFile
     # Default
     else:
-        resultFile = "check-results_{0}.csv".format(os.path.splitext(os.path.basename(inputFileName))[0])
+        if not outputFileName:
+            resultFile = "check-results_{0}.csv".format(os.path.splitext(os.path.basename(inputFileName))[0])
+        else:
+            resultFile = outputFileName
         if os.path.exists(resultFile):
             print("[+] Found results CSV from previous run: {0}".format(resultFile))
             print("[+] Appending results to file: {0}".format(resultFile))
             alreadyExists = True
         else:
             print("[+] Writing results to new file: {0}".format(resultFile))
-        return alreadyExists, resultFile
+
+    # return file
+    return alreadyExists, resultFile

--- a/lib/munin_csv.py
+++ b/lib/munin_csv.py
@@ -1,5 +1,4 @@
 import codecs
-import sys
 import traceback
 from lib.munin_vt import VENDORS
 
@@ -72,12 +71,6 @@ def writeCSV(info, resultFile):
                 else:
                     fh_results.write("-;")
             fh_results.write('\n')
-    except FileNotFoundError:
-        print("[E] Output path does not exist.")
-        sys.exit(1)
-    except PermissionError:
-        print("[E] Missing permission to write to output file.")
-        sys.exit(1)
     except:
         traceback.print_exc()
         return False

--- a/lib/munin_csv.py
+++ b/lib/munin_csv.py
@@ -1,4 +1,5 @@
 import codecs
+import sys
 import traceback
 from lib.munin_vt import VENDORS
 
@@ -71,6 +72,12 @@ def writeCSV(info, resultFile):
                 else:
                     fh_results.write("-;")
             fh_results.write('\n')
+    except FileNotFoundError:
+        print("[E] Output path does not exist.")
+        sys.exit(1)
+    except PermissionError:
+        print("[E] Missing permission to write to output file.")
+        sys.exit(1)
     except:
         traceback.print_exc()
         return False

--- a/munin-host.py
+++ b/munin-host.py
@@ -669,8 +669,8 @@ if __name__ == '__main__':
 
     # Result file
     if not args.nocsv:
-        result_file = "check-results_{0}.csv".format(os.path.splitext(os.path.basename(args.f))[0])
-        if os.path.exists(result_file):
+        alreadyExists, result_file = generateResultFilename(args.f, args.o)
+        if alreadyExists:
             print("[+] Found results CSV from previous run: {0}".format(result_file))
             print("[+] Appending results to file: {0}".format(result_file))
         else:

--- a/munin.py
+++ b/munin.py
@@ -10,6 +10,7 @@ pip install -r requirements.txt
 pip3 install -r requirements.txt
 """
 
+import codecs
 import configparser
 import requests
 from requests.auth import HTTPBasicAuth
@@ -1036,6 +1037,7 @@ if __name__ == '__main__':
 
 
     # DEFAULT -----------------------------------------------------------------
+
     # Open input file
     if args.f:
         # Generate a result file name
@@ -1046,6 +1048,8 @@ if __name__ == '__main__':
         except Exception as e:
             print("[E] Cannot read input file")
             sys.exit(1)
+
+    # Process sample folder
     if args.s:
         # Generate a result file name
         pathComps = args.s.split(os.sep)
@@ -1065,6 +1069,17 @@ if __name__ == '__main__':
                     lines.append("{0} {1}".format(hashes["sha256"], filePath))
                 except Exception as e:
                     traceback.print_exc()
+
+    # Check output file
+    if args.o:
+        try:
+            codecs.open(args.o, 'a', encoding='utf8')
+        except FileNotFoundError:
+            print("[E] Output path does not exist.")
+            sys.exit(1)
+        except PermissionError:
+            print("[E] Missing permission to write to output file.")
+            sys.exit(1)
 
     # Missing operation mode
     if not args.web and not args.cli and not args.f and not args.s:

--- a/munin.py
+++ b/munin.py
@@ -243,7 +243,7 @@ def processLines(lines, resultFile, nocsv=False, debug=False):
         # Platform Checks
         platformChecks(info)
 
-        # Wait the remaining colldown time
+        # Wait the remaining cooldown time
         time.sleep(cooldown_time)
 
     return infos
@@ -904,6 +904,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Online Hash Checker')
     parser.add_argument('-f', help='File to process (hash line by line OR csv with hash in each line - auto-detects '
                                    'position and comment)', metavar='path', default='')
+    parser.add_argument('-o', help='Output file for results (CSV)', metavar='output', default='')
     parser.add_argument('-c', help='Name of the cache database file (default: vt-hash-db.pkl)', metavar='cache-db',
                         default='vt-hash-db.json')
     parser.add_argument('-i', help='Name of the ini file that holds the API keys', metavar='ini-file',
@@ -996,7 +997,7 @@ if __name__ == '__main__':
     # CLI ---------------------------------------------------------------------
     # Check input file
     if args.cli:
-        alreadyExists, resultFile = generateResultFilename(args.f)
+        alreadyExists, resultFile = generateResultFilename(args.f, args.o)
         print("")
         print("Command Line Interface Mode")
         print("")
@@ -1028,7 +1029,7 @@ if __name__ == '__main__':
         print("")
         print("Web Service Mode")
         print("")
-        alreadyExists, resultFile = generateResultFilename(args.f)
+        alreadyExists, resultFile = generateResultFilename(args.f, args.o)
         print("Send your requests to http://server:%d/value" % int(args.w))
         printKeyLine("STARTING FLASK")
         app.run(port=int(args.w))
@@ -1038,7 +1039,7 @@ if __name__ == '__main__':
     # Open input file
     if args.f:
         # Generate a result file name
-        alreadyExists, resultFile = generateResultFilename(args.f)
+        alreadyExists, resultFile = generateResultFilename(args.f, args.o)
         try:
             with open(args.f, 'r') as fh:
                 lines = fh.readlines()
@@ -1050,7 +1051,7 @@ if __name__ == '__main__':
         pathComps = args.s.split(os.sep)
         if pathComps[-1] == "":
             del pathComps[-1]
-        alreadyExists, resultFile = generateResultFilename(pathComps[-1])
+        alreadyExists, resultFile = generateResultFilename(pathComps[-1], args.o)
         # Empty lines container
         lines = []
         for root, directories, files in os.walk(args.s, followlinks=False):


### PR DESCRIPTION
Hi,

I added an optional argument to choose another output file (path) than the one created by default. Some error handling takes place before the VT checks start. And I fixed one or two typos.

The [typical command lines](https://github.com/Neo23x0/munin#typical-command-lines) show some examples with `intense` mode. Looks to me that the feature was deprecated with ec0d424697f8f35d3ec9f6721ee5d687a91fda7c but I was not sure, whether to remove them or not.

Greetings
stuhli