### PR TITLE
Updates to munin-host.py 

### DIFF
--- a/munin-host.py
+++ b/munin-host.py
@@ -34,7 +34,6 @@ from lib.helper import generateResultFilename
 
 URLS = {'ip': r'https://www.virustotal.com/vtapi/v2/ip-address/report',
         'domain': r'https://www.virustotal.com/vtapi/v2/domain/report'}
-API_KEY = ''
 WAIT_TIME = 15  # Public API allows 4 request per minute, so we wait 15 secs by default
 IP_WHITE_LIST = ['1.0.0.127', '127.0.0.1']
 OWNER_WHITE_LIST = ['Google Inc.', 'Facebook, Inc.', 'CloudFlare, Inc.', 'Microsoft Corporation',
@@ -271,12 +270,12 @@ def process_elements(elements, result_file, max_items, nocsv=False, dups=False, 
 
         # VT API Request ---------------------------------------------------------------------------------------
         # Prepare VT API request
-        parameters = {cat: value, "apikey": API_KEY}
+        parameters = {cat: value, "apikey": VT_PUBLIC_API_KEY}
         success = False
 
         while not success:
             try:
-                parameters = {cat: value, 'apikey': API_KEY}
+                parameters = {cat: value, 'apikey': VT_PUBLIC_API_KEY}
                 if debug:
                     print("URL: %s" % URLS[cat])
                     print("PARAMS: %s" % parameters)

--- a/munin-host.py
+++ b/munin-host.py
@@ -631,7 +631,6 @@ if __name__ == '__main__':
         VT_PUBLIC_API_KEY = config['DEFAULT']['VT_PUBLIC_API_KEY']
         MAL_SHARE_API_KEY = config['DEFAULT']['MAL_SHARE_API_KEY']
         PAYLOAD_SEC_API_KEY = config['DEFAULT']['PAYLOAD_SEC_API_KEY']
-        PAYLOAD_SEC_API_SECRET = config['DEFAULT']['PAYLOAD_SEC_API_SECRET']
         MISP_URL = config['MISP']['MISP_URL']
         MISP_API_KEY = config['MISP']['MISP_API_KEY']
     except Exception as e:

--- a/munin-host.py
+++ b/munin-host.py
@@ -631,8 +631,6 @@ if __name__ == '__main__':
         VT_PUBLIC_API_KEY = config['DEFAULT']['VT_PUBLIC_API_KEY']
         MAL_SHARE_API_KEY = config['DEFAULT']['MAL_SHARE_API_KEY']
         PAYLOAD_SEC_API_KEY = config['DEFAULT']['PAYLOAD_SEC_API_KEY']
-        MISP_URL = config['MISP']['MISP_URL']
-        MISP_API_KEY = config['MISP']['MISP_API_KEY']
     except Exception as e:
         traceback.print_exc()
         print("[E] Config file '%s' not found" % args.i)

--- a/munin-host.py
+++ b/munin-host.py
@@ -676,7 +676,7 @@ if __name__ == '__main__':
             try:
                 with open(result_file, 'w') as fh_results:
                     fh_results.write(
-                        "IP;Rating;Owner;Country Code;Log Line No;Positives;Total;Malicious Samples;Hosts\n")
+                        "IP;Rating;Owner;Country Code;Positives;Total;Malicious Samples;Hosts\n")
             except Exception as e:
                 print("[E] Cannot write CSV export file: {0}".format(result_file))
 

--- a/munin-host.py
+++ b/munin-host.py
@@ -30,6 +30,7 @@ import ssl
 import dns.resolver
 from IPy import IP
 from colorama import init, Fore, Back, Style
+from lib.helper import generateResultFilename
 
 URLS = {'ip': r'https://www.virustotal.com/vtapi/v2/ip-address/report',
         'domain': r'https://www.virustotal.com/vtapi/v2/domain/report'}
@@ -498,7 +499,7 @@ def download_url(host_id, url):
     # Write File
     if c.getinfo(c.RESPONSE_CODE) == 200:
         # Check folder
-        out_path = os.path.join(os.path.abspath(args.o), host_id)
+        out_path = os.path.join(os.path.abspath(args.d), host_id)
         if not os.path.exists(out_path):
             os.makedirs(out_path)
         # Output file name
@@ -600,6 +601,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Virustotal Online Checker (IP/Domain)')
     parser.add_argument('-f', help='File to process (hash line by line OR csv with hash in each line - auto-detects '
                                    'position and comment)', metavar='path', default='')
+    parser.add_argument('-o', help='Output file for results (CSV)', metavar='output', default='')
     parser.add_argument('-m', help='Maximum number of items (urls, hosts, samples) to show', metavar='max-items',
                         default=10)
     parser.add_argument('-c', help='Name of the cache database file (default: vt-hosts-db.json)', metavar='cache-db',
@@ -612,7 +614,7 @@ if __name__ == '__main__':
     parser.add_argument('--recursive', action='store_true', help='Process the resolved IPs as well', default=False)
     parser.add_argument('--download', action='store_true',
                         help='Try to download the URLs (directories with host/ip names)', default=False)
-    parser.add_argument('-o', help='Store the downloads to the given directory', metavar='output-folder',
+    parser.add_argument('-d', help='Store the downloads to the given directory', metavar='download_path',
                         default='./')
     parser.add_argument('--dups', action='store_true', help='Do not skip duplicate hashes', default=False)
     parser.add_argument('--noresolve', action='store_true', help='Do not perform DNS resolve test on found domain '

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ flask>=1.0
 flask_caching
 cfscrape
 pyzipper
+dnspython
+IPy


### PR DESCRIPTION
Mainly stuff to implement the changed munin.ini format and some additional fixes:
* Removed variable parsing for PAYLOAD_SEC_API_SECRET (Hybrid Analysis API v2 doesn't use an API SECRET)
* Parsing of MISP_URLS and MISP_AUTH_KEYS from munin.ini was broken. As munin-host.py currently doesn't support MISP lookup I removed the parsing for now.
* Changed VirusTotal processor to use VT_PUBLIC_API_KEY variable instead of 'API_KEY'
* Aligned -o and -d parameters to munin.py
* Removed 'Log Line No' from the CSV template as it is not filled
* Added dnspython and IPy modules to requirements.txt