### PR TITLE
Fix for #53 (debug switch not passed to getVTInfo)

### DIFF
--- a/munin.py
+++ b/munin.py
@@ -171,7 +171,7 @@ def processLine(line, debug):
 
         # Get Information
         # Virustotal
-        vt_info = munin_vt.getVTInfo(hashVal)
+        vt_info = munin_vt.getVTInfo(hashVal, args.debug)
         info.update(vt_info)
         # MISP
         misp_info = getMISPInfo(hashVal)


### PR DESCRIPTION
This is my suggested fix for #53, which prevents debug messages from displaying during the `getVTInfo` function. As noted in the issue, the while loop in `getVTInfo` is prone to silent failure and endless looping (#29) and the lack of debug info even when the `--debug` switch is applied makes it look like everything is fine if you're not familiar with the program's normal output.

The fix is simply to supply the `args.debug` value to the `getVTInfo` function, as appears to be standard elsewhere in the application.