### PR TITLE
Some QoL updates

### DIFF
--- a/lib/munin_csv.py
+++ b/lib/munin_csv.py
@@ -2,7 +2,7 @@ import codecs
 import traceback
 from lib.munin_vt import VENDORS
 
-CSV_FIELD_ORDER = ['Lookup Hash', 'Rating', 'Comment', 'Positives', 'Virus', 'File Names', 'First Submitted',
+CSV_FIELD_ORDER = ['Lookup Hash', 'Rating', 'Comment', 'Positives', 'File Size', 'Virus', 'File Names', 'First Submitted',
                    'Last Submitted', 'File Type', 'MD5', 'SHA1', 'SHA256', 'Imphash', 'Matching Rule', 'Harmless', 'Revoked',
                    'Expired', 'Trusted', 'Signed', 'Signer', 'Hybrid Analysis Sample', 'MalShare Sample',
                    'VirusBay Sample', 'MISP', 'MISP Events', 'URLhaus', 'AnyRun', 'CAPE', 'VALHALLA', 'User Comments']

--- a/lib/munin_vt.py
+++ b/lib/munin_vt.py
@@ -73,6 +73,9 @@ def getRetrohuntResults(retrohunt_id, no_comments=False, debug=False):
             break
 
         for file in response_json["data"]:
+            if "error" in file:
+                print("[W] Skipping file {} due to error: {}".format(file["id"], file["error"]["message"]))
+                continue
             file_info = processVirustotalSampleInfo(file, debug)
             file_info['hash'] = file["id"]  # Add hash info manually, since no original hash exists
             file_info['matching_rule'] = file["context_attributes"]["rule_name"]

--- a/lib/munin_vt.py
+++ b/lib/munin_vt.py
@@ -57,7 +57,7 @@ def getVTInfo(hash, debug=False):
 
 def getRetrohuntResults(retrohunt_id, no_comments=False, debug=False):
     headers = { 'x-apikey': VT_PUBLIC_API_KEY}
-    url = "%s/%s/matching_files?limit=500" % (RETROHUNT_URL, retrohunt_id)
+    url = "%s/%s/matching_files?limit=300" % (RETROHUNT_URL, retrohunt_id)
     files = []
     while True:
         response = requests.get(url, headers=headers, proxies=PROXY)


### PR DESCRIPTION
- add file size to retrohunt CSV output
- change query limit to not hit API limits
- skip files which are removed from VT (otherwise munin/hugin crashes)