### PR TITLE
add command line option to get VT output of all AV vendors, small fixes to  README.md, optionally wait on VT quota exceed, add --limit, add VT comment tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Default Mode - Read Hashes from File
 ## Operation Modes
 
 1. Default - by providing an input file (-f) with hashes or sample directory (-s)
-2. Command Line Interface - using the --cli paramerter
-3. Web Service Mode - using the --web paramerter
+2. Command Line Interface - using the --cli parameter
+3. Web Service Mode - using the --web parameter
 
 ## Getting started
 
@@ -193,7 +193,7 @@ In the default, it will create a CSV file with the current date in the file name
 
 ## Web Service Mode
 
-Start munin with `--web` and optionall select a port `-w port`. 
+Start munin with `--web` and optional select a port `-w port`. 
 
 E.g. 
 ```bash
@@ -273,7 +273,7 @@ The result will look like this:
 }
 ```
 
-The queries to Virustotal need to be throttled. Therefore the web service applies a cool down time, that is minimized by substracting the time it took to process all other platforms from the wait time of 15 seconds. 
+The queries to Virustotal need to be throttled. Therefore the web service applies a cool down time, that is minimized by subtracting the time it took to process all other platforms from the wait time of 15 seconds. 
 ```
 cooldown_time = vt_wait_time - process_time
 ```
@@ -291,7 +291,7 @@ The Munin host and IP checker script (`munin-host.py`) retrieves more informatio
 
 ## Usage
 
-```bash
+```
 usage: munin.py [-h] [-f path] [-c cache-db] [-i ini-file] [-s sample-folder]
                 [--comment] [-p vt-comment-prefix] [--download]
                 [-d download_path] [--nocache] [--intense] [--nocsv]
@@ -339,7 +339,7 @@ python3 munin-host.py -i your-key.ini -f ./munin-hosts-demo.txt --noresolve --do
 
 ## Warning
 
-Using `munin-host.py` in an IDS monitored network will cause numerous alerts as munin-host.py performs DNS lookups for malicous domains and has the option to download malicious samples. 
+Using `munin-host.py` in an IDS monitored network will cause numerous alerts as munin-host.py performs DNS lookups for malicious domains and has the option to download malicious samples. 
 
 ## Issues
 
@@ -365,7 +365,7 @@ The Hugin script (`hugin.py`) retrieves and displays information to all samples 
 
 ## Usage
 
-```bash
+```
 usage: hugin.py [-h] [-r retrohunt-name] [-i ini-file]
                 [--csv-path CSV_PATH] [--debug] [--no-comments]
 

--- a/lib/munin_vt.py
+++ b/lib/munin_vt.py
@@ -54,6 +54,7 @@ def getVTInfo(hash, debug=False, vtallvendors=False, QUOTA_EXCEEDED_WAIT_TIME=60
         info.update(searchVirustotalComments(info["sha256"], debug))
 
     info['hash'] = hash
+    info['tags'] = uniqList(info['tags'])
 
     # Harmless - TODO: Legacy features
     if "Probably harmless!" in response_dict_code:
@@ -63,6 +64,9 @@ def getVTInfo(hash, debug=False, vtallvendors=False, QUOTA_EXCEEDED_WAIT_TIME=60
         info['mssoft'] = True
     return info
 
+def uniqList(listx):
+    # returns the unique elements of a list
+    return list(set(listx))
 
 def getRetrohuntResults(retrohunt_id, no_comments=False, debug=False, vtallvendors=False):
     headers = { 'x-apikey': VT_PUBLIC_API_KEY}
@@ -95,6 +99,9 @@ def getRetrohuntResults(retrohunt_id, no_comments=False, debug=False, vtallvendo
                     "comments": 0,
                     "commenter": []
                 })
+
+            file_info['tags'] = uniqList(file_info['tags'])
+
             files.append(file_info)
 
         # Print dot to indicate progress
@@ -264,7 +271,8 @@ def processVirustotalSampleInfo(sample_info, debug=False, vtallvendors=False):
 def searchVirustotalComments(sha256, debug=False):
     info = {
         "comments": 0,
-        "commenter": ['-']
+        "commenter": ['-'],
+        "tags": []
     }
 
     try:
@@ -283,6 +291,9 @@ def searchVirustotalComments(sha256, debug=False):
             info['commenter'] = []
             for com in r_comments['data']:
                 info['commenter'].append(com['relationships']['author']['data']['id'])
+                info['tags'].extend(com['attributes']['tags'])
+
+
     except Exception:
         if debug:
             traceback.print_exc()

--- a/lib/munin_vt.py
+++ b/lib/munin_vt.py
@@ -4,6 +4,7 @@ import math
 import requests
 import os
 import traceback
+import time
 from lib.connections import PROXY
 
 RETROHUNT_URL = 'https://www.virustotal.com/api/v3/intelligence/retrohunt_jobs'
@@ -14,7 +15,7 @@ VENDORS = ['Microsoft', 'Kaspersky', 'McAfee', 'CrowdStrike', 'TrendMicro',
 
 VT_PUBLIC_API_KEY = "-"
 
-def getVTInfo(hash, debug=False, vtallvendors=False):
+def getVTInfo(hash, debug=False, vtallvendors=False, QUOTA_EXCEEDED_WAIT_TIME=600, vtwaitquota=False):
     """
     Retrieves many different attributes of a sample from Virustotal via its hash
     :param hash:
@@ -30,6 +31,14 @@ def getVTInfo(hash, debug=False, vtallvendors=False):
             success = True
             if response_dict_code.status_code == 429:
                 print("VirusTotal Quota exceeded.")
+
+                # only wait if --vtwaitquota to avoid breaking change, and users might be interessested in the results of the other services
+                if vtwaitquota:
+                    print("Waiting for %d seconds before next try." % QUOTA_EXCEEDED_WAIT_TIME)
+                    time.sleep(QUOTA_EXCEEDED_WAIT_TIME)
+
+                    # to stay in while loop
+                    success = False
         except Exception as e:
             if debug:
                 traceback.print_exc()

--- a/munin.py
+++ b/munin.py
@@ -171,7 +171,7 @@ def processLine(line, debug):
 
         # Get Information
         # Virustotal
-        vt_info = munin_vt.getVTInfo(hashVal, args.debug)
+        vt_info = munin_vt.getVTInfo(hashVal, args.debug, args.vtallvendors)
         info.update(vt_info)
         # MISP
         misp_info = getMISPInfo(hashVal)
@@ -1168,6 +1168,7 @@ if __name__ == '__main__':
     parser.add_argument('-f', help='File to process (hash line by line OR csv with hash in each line - auto-detects '
                                    'position and comment)', metavar='path', default='')
     parser.add_argument('-o', help='Output file for results (CSV)', metavar='output', default='')
+    parser.add_argument('--vtallvendors', action='store_true', help='Output VT malware names for all AV vendors (Default is Top10)', default=False)
     parser.add_argument('-c', help='Name of the cache database file (default: vt-hash-db.pkl)', metavar='cache-db',
                         default='vt-hash-db.json')
     parser.add_argument('-i', help='Name of the ini file that holds the API keys', metavar='ini-file',
@@ -1193,6 +1194,7 @@ if __name__ == '__main__':
     parser.add_argument('--debug', action='store_true', default=False, help='Debug output')
     
     args = parser.parse_args()
+
 
     # PyMISP error handling > into Nirvana # No Longer needed as debug=args.debug will print this anyway
     # logger = logging.getLogger("pymisp")

--- a/munin.py
+++ b/munin.py
@@ -66,6 +66,8 @@ PAYLOAD_SEC_API_KEY = '-'
 
 WAIT_TIME = 17  # Public API allows 4 request per minute, so we wait 15 secs by default
 
+QUOTA_EXCEEDED_WAIT_TIME = 1200  # wait if quota is exceeded and --vtwaitquota is used
+
 TAGS = ['HARMLESS', 'SIGNED', 'MSSOFT', 'REVOKED', 'EXPIRED']
 
 # MalwareShare URL
@@ -171,7 +173,7 @@ def processLine(line, debug):
 
         # Get Information
         # Virustotal
-        vt_info = munin_vt.getVTInfo(hashVal, args.debug, args.vtallvendors)
+        vt_info = munin_vt.getVTInfo(hashVal, args.debug, args.vtallvendors, QUOTA_EXCEEDED_WAIT_TIME, args.vtwaitquota)
         info.update(vt_info)
         # MISP
         misp_info = getMISPInfo(hashVal)
@@ -1169,6 +1171,7 @@ if __name__ == '__main__':
                                    'position and comment)', metavar='path', default='')
     parser.add_argument('-o', help='Output file for results (CSV)', metavar='output', default='')
     parser.add_argument('--vtallvendors', action='store_true', help='Output VT malware names for all AV vendors (Default is Top10)', default=False)
+    parser.add_argument('--vtwaitquota', action='store_true', help='Do not continue if VT quota is exceeded but wait for the next day', default=False)
     parser.add_argument('-c', help='Name of the cache database file (default: vt-hash-db.pkl)', metavar='cache-db',
                         default='vt-hash-db.json')
     parser.add_argument('-i', help='Name of the ini file that holds the API keys', metavar='ini-file',


### PR DESCRIPTION


````bash` colorizes bash keywords in the help text

![image](https://user-images.githubusercontent.com/46819580/212490870-ba77a3e1-4880-4959-8eb9-95a9cb3e21b2.png)
