### PR TITLE
Update munin.py

### DIFF
--- a/munin.py
+++ b/munin.py
@@ -969,7 +969,7 @@ def platformChecks(info):
     try:
         # Malware Share availability
         if 'malshare_available' in info:
-            if info['malshare_available']:
+            if info['malshare_available'] and not info['malshare_available'] == '-':
                 printHighlighted("[!] Sample is available on malshare.com URL: {0}{1}".format(
                     MAL_SHARE_LINK, info['md5']))
     except KeyError as e:
@@ -1024,7 +1024,7 @@ def platformChecks(info):
     try:
         # AnyRun availability
         if 'anyrun_available' in info:
-            if info['anyrun_available']:
+            if info['anyrun_available'] and not info['anyrun_available'] == '-':
                 printHighlighted("[!] Sample on ANY.RUN URL: %s" % (URL_ANYRUN % info['sha256']))
     except KeyError as e:
         if args.debug:


### PR DESCRIPTION
Small bugfix to avoid cached results falsely shown as having samples available on malshare and anyrun.

(in the vt-hash-db.json is a mix of filling boolean negative fields with "false" and "-" and the minus evaluates to True. not easy fixable in my understanding)