### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+urllib3<2
 colorama>=0.3.9
 future>=0.16.0
 requests>=2.20.0


### PR DESCRIPTION
Prevent this error in newer environments:
```
   from urllib3.util.ssl_ import create_urllib3_context, DEFAULT_CIPHERS
ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (.pyenv/versions/3.12.1/lib/python3.12/site-packages/urllib3/util/ssl_.py)
```